### PR TITLE
Added feed variable

### DIFF
--- a/harp.json
+++ b/harp.json
@@ -4,6 +4,7 @@
     "title": "Simurai",
     "url": "http://github.com/kennethormandy/hb-simurai",
     "description": "Simurai’s site as a Harp boilerplate.",
+    "feed": "https://hb-simurai.surge.sh/blog/atom.xml"
     "authors": {
       "simurai": {
         "name": "Simurai",

--- a/public/_includes/aside.ejs
+++ b/public/_includes/aside.ejs
@@ -2,7 +2,7 @@
   <a href="/">
     <!-- If you want to use your picture instead,
          you can give the image the `aside-avatar` class -->
-    <img class="" src="<%= base %>img/stamp.svg" alt="<%= name %> avatar">
+    <img class="" src="/img/stamp.svg" alt="<%= name %> avatar">
   </a>
   <a class="aside-hamburger" href="#top"></a>
   <div class="aside-target">

--- a/public/_includes/head.ejs
+++ b/public/_includes/head.ejs
@@ -10,7 +10,5 @@
 
   <link rel="stylesheet" href="/css/main.css">
 
-  <!-- {% if page.blog %}
-  <link rel="alternate" type="application/atom+xml" title="simurai" href="http://feeds.feedburner.com/simurai">
-  {% endif %} -->
+  <link rel="alternate" type="application/atom+xml" title="<%= title %>" href="<%= feed %>">
 </head>

--- a/public/blog/index.ejs
+++ b/public/blog/index.ejs
@@ -14,6 +14,7 @@
           </h2>
           <% if(post.author) { %><span class="meta-author">
             <a href="http://twitter.com/<%= authors[post.author].twitter %>"><%= authors[post.author].name %></a>
+            </span>
           <% } %>
           <time class="time time--inline"> on <%= post.date %></time>
         </a>

--- a/public/index.ejs
+++ b/public/index.ejs
@@ -12,8 +12,9 @@
           <h2 class="index-title">
             <%= post.title %>
           </h2>
-          <% if(post.author) { %>
+          <% if(post.author) { %><span class="meta-author">
             <a href="http://twitter.com/<%= authors[post.author].twitter %>"><%= authors[post.author].name %></a>
+            </span>
           <% } %>
           <time class="time time--inline"> on <%= post.date %></time>
         </a>


### PR DESCRIPTION
The feed link in head.ejs was pointing to simurai's feedburner location. It should be customisable variable. Also:
- in head.ejs: the `page.blog` doesn't seem to be defined
- in aside.ejs: the `base` variable  doesn't seem to be defined, and would result in the stamp image not found when loading pages such as `404.ejs`
